### PR TITLE
Rename `foo` to `application`

### DIFF
--- a/demo_python_at/commoms/application.py
+++ b/demo_python_at/commoms/application.py
@@ -4,13 +4,13 @@ from demo_python_at.commoms.message import Message
 from demo_python_at.commoms.printer import Printer
 
 
-class Foo(ABC):
+class Application(ABC):
     @abstractmethod
     def print(self):
         pass
 
 
-class SimpleFoo(Foo):
+class SimpleApplication(Application):
     def __init__(self, printer: Printer, message: Message):
         self._printer = printer
         self._message = message

--- a/demo_python_at/tests/smoke_test.py
+++ b/demo_python_at/tests/smoke_test.py
@@ -1,7 +1,7 @@
-from demo_python_at.commoms.foo import SimpleFoo
+from demo_python_at.commoms.application import SimpleApplication
 from demo_python_at.commoms.message import HtmlMessage, StrMessage
 from demo_python_at.commoms.printer import StdoutPrinter
 
 
 def test_foo():
-    SimpleFoo(StdoutPrinter(), HtmlMessage(StrMessage("Hello"))).print()
+    SimpleApplication(StdoutPrinter(), HtmlMessage(StrMessage("Hello"))).print()


### PR DESCRIPTION
Renaming also affects inheriting class `SimpleFoo` -> `SimpleApplication`.

Affects #14