### PR TITLE
Configure pydocstyle

### DIFF
--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,0 +1,2 @@
+[pydocstyle]
+ignore = D1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 flake8==3.3.0
 pytest-cov==2.5.1
+pydocstyle==2.0.0

--- a/verify_project.sh
+++ b/verify_project.sh
@@ -3,5 +3,6 @@ set -e
 
 py.test --cov=demo_python_at
 flake8 demo_python_at/
+pydocstyle --config=.pydocstyle demo_python_at
 
 echo "Good job!"


### PR DESCRIPTION
Add pydocstyle dependency to requirements-dev.txt.
Add .pydocstyle configuration file and configure to ignore Missing
Docstring violations.
Modify verify_project.sh to invoke pydocstyle check after unit
testing.

Affects #7