### PR TITLE
Enable D101 rule for pydocstyle

### DIFF
--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,2 +1,11 @@
 [pydocstyle]
-ignore = D1
+
+# D100: Missing docstring in public module
+# D102: Missing docstring in public method
+# D103: Missing docstring in public function
+# D104: Missing docstring in public package
+# D105: Missing docstring in magic method
+# D211: No blank lines allowed before class docstring
+# D212: Multi-line docstring summary should start at the first line
+
+ignore = D100,D102,D103,D104,D105,D211,D212

--- a/demo_python_at/commons/application.py
+++ b/demo_python_at/commons/application.py
@@ -5,12 +5,23 @@ from demo_python_at.commons.printer import Printer
 
 
 class Application(ABC):
+
+    """Base class for all applications."""
+
     @abstractmethod
     def print(self):
         pass
 
 
 class SimpleApplication(Application):
+
+    """
+    Class that simply prints out text.
+
+    It aggregates the Printer and Message class instances and
+    performs printing the content of Message instance.
+    """
+
     def __init__(self, printer: Printer, message: Message):
         self._printer = printer
         self._message = message

--- a/demo_python_at/commons/message.py
+++ b/demo_python_at/commons/message.py
@@ -2,6 +2,9 @@ from abc import ABC, abstractmethod
 
 
 class Message(ABC):
+
+    """Base class for all messages."""
+
     @abstractmethod
     def data(self) -> str:
         pass
@@ -12,6 +15,9 @@ class Message(ABC):
 
 
 class StrMessage(Message):
+
+    """Class that stores a message in string format."""
+
     def __init__(self, message: str):
         self._message = message
 
@@ -23,6 +29,9 @@ class StrMessage(Message):
 
 
 class HtmlMessage(Message):
+
+    """Class that stores a message in html format."""
+
     def __init__(self, base: Message):
         self._message = base
 
@@ -34,6 +43,13 @@ class HtmlMessage(Message):
 
 
 class FakeMessage(Message):
+
+    """
+    Class that stores a message and has field values by default.
+
+    Field values will be set as default if not specified in constructor.
+    """
+
     def __init__(self, message: str = "", exist: bool = False):
         self._message = message
         self._exist = exist

--- a/demo_python_at/commons/printer.py
+++ b/demo_python_at/commons/printer.py
@@ -4,11 +4,17 @@ from demo_python_at.commons.message import Message
 
 
 class Printer(ABC):
+
+    """Base class for all printers."""
+
     @abstractmethod
     def print(self, message: Message):
         pass
 
 
 class StdoutPrinter(Printer):
+
+    """Class that prints a message to console."""
+
     def print(self, message: Message):
         print(message.data())


### PR DESCRIPTION
Added class docstrings to fix violations.

D211 and D212 rules were disabled because there must be chosen 1 out of 2 rules.
For example:
D213: Multi-line docstring summary should start at the second line.
D212: Multi-line docstring summary should start at the first line.

Affects #24 