### PR TITLE
Enable D102 rule for pydocstyle

### DIFF
--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,11 +1,9 @@
 [pydocstyle]
-
 # D100: Missing docstring in public module
-# D102: Missing docstring in public method
 # D103: Missing docstring in public function
 # D104: Missing docstring in public package
 # D105: Missing docstring in magic method
 # D211: No blank lines allowed before class docstring
 # D212: Multi-line docstring summary should start at the first line
 
-ignore = D100,D102,D103,D104,D105,D211,D212
+ignore = D100,D103,D104,D105,D211,D212

--- a/demo_python_at/commons/application.py
+++ b/demo_python_at/commons/application.py
@@ -10,6 +10,7 @@ class Application(ABC):
 
     @abstractmethod
     def print(self):
+        """Abstract method for printing."""
         pass
 
 
@@ -23,8 +24,15 @@ class SimpleApplication(Application):
     """
 
     def __init__(self, printer: Printer, message: Message):
+        """
+        Initialize SimpleApplication object.
+
+        :param printer: Printer class object
+        :param message: Message class object
+        """
         self._printer = printer
         self._message = message
 
     def print(self):
+        """Print message from Message class with specified Printer."""
         self._printer.print(self._message)

--- a/demo_python_at/commons/message.py
+++ b/demo_python_at/commons/message.py
@@ -7,10 +7,12 @@ class Message(ABC):
 
     @abstractmethod
     def data(self) -> str:
+        """Abstract method to return message data in string format."""
         pass
 
     @abstractmethod
     def exist(self) -> bool:
+        """Abstract method to verify if message exist and return bool."""
         pass
 
 
@@ -19,12 +21,28 @@ class StrMessage(Message):
     """Class that stores a message in string format."""
 
     def __init__(self, message: str):
+        """
+        Initialize StrMessage object.
+
+        :param message: data in string format
+        """
         self._message = message
 
     def exist(self) -> bool:
+        """
+        Verify that message length is greater than 0.
+
+        :return: True if message length is greater than 0
+                 False in other cases
+        """
         return len(self._message) > 0
 
     def data(self) -> str:
+        """
+        Get message data.
+
+        :return: message data in string format
+        """
         return self._message
 
 
@@ -33,12 +51,27 @@ class HtmlMessage(Message):
     """Class that stores a message in html format."""
 
     def __init__(self, base: Message):
+        """
+        Initialize HtmlMessage object.
+
+        :param base: Message class object
+        """
         self._message = base
 
     def data(self):
+        """
+        Reformat message data in HTML paragraph.
+
+        :return: reformatted message data in string format
+        """
         return "<p>{m}</p>".format(m=self._message.data())
 
     def exist(self):
+        """
+        Verify if message exists.
+
+        :return: existence state of message as bool
+        """
         return self._message.exist()
 
 
@@ -51,11 +84,27 @@ class FakeMessage(Message):
     """
 
     def __init__(self, message: str = "", exist: bool = False):
+        """
+        Initialize FakeMessage object.
+
+        :param message: data in string format or "" by default
+        :param exist: whether data exist or False by default
+        """
         self._message = message
         self._exist = exist
 
     def exist(self) -> bool:
+        """
+        Get existence state of message.
+
+        :return: existence state of message as bool
+        """
         return self._exist
 
     def data(self) -> str:
+        """
+        Get message data.
+
+        :return: message data in string format
+        """
         return self._message

--- a/demo_python_at/commons/printer.py
+++ b/demo_python_at/commons/printer.py
@@ -9,6 +9,7 @@ class Printer(ABC):
 
     @abstractmethod
     def print(self, message: Message):
+        """Abstract method for printing."""
         pass
 
 
@@ -17,4 +18,9 @@ class StdoutPrinter(Printer):
     """Class that prints a message to console."""
 
     def print(self, message: Message):
+        """
+        Print given message in stdout.
+
+        :param message: Message class object
+        """
         print(message.data())


### PR DESCRIPTION
Add docstrings for public methods.
Modify .pydocstyle to enable D102 rule but ignore D212 rule to
resolve conflicting rules.

Affects #25 