### PR TITLE
Enable D211 rule for pydocstyle

### DIFF
--- a/.pydocstyle
+++ b/.pydocstyle
@@ -2,7 +2,7 @@
 # D100: Missing docstring in public module
 # D104: Missing docstring in public package
 # D105: Missing docstring in magic method
-# D211: No blank lines allowed before class docstring
+# D203: 1 blank line required before class docstring
 # D212: Multi-line docstring summary should start at the first line
 
-ignore = D100,D104,D105,D211,D212
+ignore = D100,D104,D105,D203,D212

--- a/demo_python_at/commons/application.py
+++ b/demo_python_at/commons/application.py
@@ -5,7 +5,6 @@ from demo_python_at.commons.printer import Printer
 
 
 class Application(ABC):
-
     """Base class for all applications."""
 
     @abstractmethod
@@ -15,7 +14,6 @@ class Application(ABC):
 
 
 class SimpleApplication(Application):
-
     """
     Class that simply prints out text.
 

--- a/demo_python_at/commons/message.py
+++ b/demo_python_at/commons/message.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 
 
 class Message(ABC):
-
     """Base class for all messages."""
 
     @abstractmethod
@@ -17,7 +16,6 @@ class Message(ABC):
 
 
 class StrMessage(Message):
-
     """Class that stores a message in string format."""
 
     def __init__(self, message: str):
@@ -47,7 +45,6 @@ class StrMessage(Message):
 
 
 class HtmlMessage(Message):
-
     """Class that stores a message in html format."""
 
     def __init__(self, base: Message):
@@ -76,7 +73,6 @@ class HtmlMessage(Message):
 
 
 class FakeMessage(Message):
-
     """
     Class that stores a message and has field values by default.
 

--- a/demo_python_at/commons/printer.py
+++ b/demo_python_at/commons/printer.py
@@ -4,7 +4,6 @@ from demo_python_at.commons.message import Message
 
 
 class Printer(ABC):
-
     """Base class for all printers."""
 
     @abstractmethod
@@ -14,7 +13,6 @@ class Printer(ABC):
 
 
 class StdoutPrinter(Printer):
-
     """Class that prints a message to console."""
 
     def print(self, message: Message):


### PR DESCRIPTION
Remove blank line before class docstrings.
Additional condition is to disable D203 because of conflicts.

Affects #29