### PR TITLE
Enable D212 rule for pydocstyle

### DIFF
--- a/.pydocstyle
+++ b/.pydocstyle
@@ -3,6 +3,6 @@
 # D104: Missing docstring in public package
 # D105: Missing docstring in magic method
 # D211: No blank lines allowed before class docstring
-# D212: Multi-line docstring summary should start at the first line
+# D213: Multi-line docstring summary should start at the second line
 
-ignore = D100,D104,D105,D211,D212
+ignore = D100,D104,D105,D211,D213

--- a/demo_python_at/commons/application.py
+++ b/demo_python_at/commons/application.py
@@ -16,16 +16,14 @@ class Application(ABC):
 
 class SimpleApplication(Application):
 
-    """
-    Class that simply prints out text.
+    """Class that simply prints out text.
 
     It aggregates the Printer and Message class instances and
     performs printing the content of Message instance.
     """
 
     def __init__(self, printer: Printer, message: Message):
-        """
-        Initialize SimpleApplication object.
+        """Initialize SimpleApplication object.
 
         :param printer: Printer class object
         :param message: Message class object

--- a/demo_python_at/commons/message.py
+++ b/demo_python_at/commons/message.py
@@ -21,16 +21,14 @@ class StrMessage(Message):
     """Class that stores a message in string format."""
 
     def __init__(self, message: str):
-        """
-        Initialize StrMessage object.
+        """Initialize StrMessage object.
 
         :param message: data in string format
         """
         self._message = message
 
     def exist(self) -> bool:
-        """
-        Verify that message length is greater than 0.
+        """Verify that message length is greater than 0.
 
         :return: True if message length is greater than 0
                  False in other cases
@@ -38,8 +36,7 @@ class StrMessage(Message):
         return len(self._message) > 0
 
     def data(self) -> str:
-        """
-        Get message data.
+        """Get message data.
 
         :return: message data in string format
         """
@@ -51,24 +48,21 @@ class HtmlMessage(Message):
     """Class that stores a message in html format."""
 
     def __init__(self, base: Message):
-        """
-        Initialize HtmlMessage object.
+        """Initialize HtmlMessage object.
 
         :param base: Message class object
         """
         self._message = base
 
     def data(self):
-        """
-        Reformat message data in HTML paragraph.
+        """Reformat message data in HTML paragraph.
 
         :return: reformatted message data in string format
         """
         return "<p>{m}</p>".format(m=self._message.data())
 
     def exist(self):
-        """
-        Verify if message exists.
+        """Verify if message exists.
 
         :return: existence state of message as bool
         """
@@ -77,15 +71,13 @@ class HtmlMessage(Message):
 
 class FakeMessage(Message):
 
-    """
-    Class that stores a message and has field values by default.
+    """Class that stores a message and has field values by default.
 
     Field values will be set as default if not specified in constructor.
     """
 
     def __init__(self, message: str = "", exist: bool = False):
-        """
-        Initialize FakeMessage object.
+        """Initialize FakeMessage object.
 
         :param message: data in string format or "" by default
         :param exist: whether data exist or False by default
@@ -94,16 +86,14 @@ class FakeMessage(Message):
         self._exist = exist
 
     def exist(self) -> bool:
-        """
-        Get existence state of message.
+        """Get existence state of message.
 
         :return: existence state of message as bool
         """
         return self._exist
 
     def data(self) -> str:
-        """
-        Get message data.
+        """Get message data.
 
         :return: message data in string format
         """

--- a/demo_python_at/commons/printer.py
+++ b/demo_python_at/commons/printer.py
@@ -18,8 +18,7 @@ class StdoutPrinter(Printer):
     """Class that prints a message to console."""
 
     def print(self, message: Message):
-        """
-        Print given message in stdout.
+        """Print given message in stdout.
 
         :param message: Message class object
         """


### PR DESCRIPTION
Update multi-line docstrings to start at the first line in `application.py`, `message.py`, `printer.py` modules.
Enable D212 rule.
Ignore D213 to resolve conflicts with D212.

Solves #30.