### PR TITLE
Use latest version of pylint static analysis tool

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 flake8==3.3.0
 pytest-cov==2.5.1
 pydocstyle==2.0.0
-pylint==1.7.1
+pylint==2.1.1


### PR DESCRIPTION
Pylint static analysis tool was raising an `Unused variable '__class__'
(unused-variable)` warning anywhere where class operator was defined.

Solution: update pylint tool to the latest version.

Close #40 